### PR TITLE
feat: update ec2 facts module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,8 @@
   tags: install_dependencies
 
 - name: Get Instance Metadata 
-  action: ec2_facts
+  ec2_metadata_facts:
+  
 
 - name: Fetch the CodeDeploy install script
   get_url:


### PR DESCRIPTION
the module used previously was not compatible with the ansible >2.8

[Doc](https://docs.ansible.com/ansible/2.4/ec2_metadata_facts_module.html)